### PR TITLE
Update viewing_alignments_basics.md

### DIFF
--- a/igv-docs/docs/UserGuide/tracks/alignments/viewing_alignments_basics.md
+++ b/igv-docs/docs/UserGuide/tracks/alignments/viewing_alignments_basics.md
@@ -22,9 +22,9 @@ BAM and CRAM files are required to have an **associated index file**.
 
 If you receive a .bam file from a sequencing facility, you will usually also get the corresponding index file. If you
 need to create the index yourself, there are multiple tools available for indexing BAM files,
-including[igvtools](../../tools/igvtools_ui.md), the[samtools](http://www.htslib.org)package, and
-the[Picard.SortSam](http://www.broadinstitute.org/cancer/software/genepattern/modules/docs/Picard.SortSam/4)module
-in[GenePattern](http://www.broadinstitute.org/cancer/software/genepattern/).
+including [igvtools](../../tools/igvtools_ui.md), the [samtools](http://www.htslib.org) package, and
+the [Picard.SortSam](http://www.broadinstitute.org/cancer/software/genepattern/modules/docs/Picard.SortSam/4) module
+in [GenePattern](http://www.broadinstitute.org/cancer/software/genepattern/).
 
 # Experiment type
 


### PR DESCRIPTION
Add whitespace around the links to indexing tools. Not sure if the lack of whitespace was intentional or note, but in my opinion it's easier to read with it, so I am proposing this change.